### PR TITLE
show subscription arn

### DIFF
--- a/nopaste.go
+++ b/nopaste.go
@@ -199,9 +199,10 @@ func snsHandler(w http.ResponseWriter, req *http.Request, chs []MessageChan) {
 			break
 		}
 		var out bytes.Buffer
-		out.WriteString(n.Type)
-		out.WriteString(n.TopicArn)
-		out.WriteString("\n")
+		fmt.Fprintf(&out, "%s from %s\n", n.Type, n.TopicArn)
+		if subscriptionArn := req.Header.Get("x-amz-sns-subscription-arn"); subscriptionArn != "" {
+			fmt.Fprintf(&out, "Subscribe by %s\n", subscriptionArn)
+		}
 		if err := json.Indent(&out, []byte(n.Message), "", "  "); err != nil {
 			out.WriteString(n.Message) // invalid JSON
 		}


### PR DESCRIPTION
If you subscribe to SNS topics with cross-accounts, you may not know which account you are subscribing to.

We have changed the Notification to check the header of the Notification request and display the ARN of the Subscription if it exists.

https://docs.aws.amazon.com/sns/latest/dg/sns-message-and-json-formats.html

According to the "x-amz-sns-subscription-arn" header, the ARN of the Subscription can be found by looking at the header of x-amz-sns-subscription-arn.
